### PR TITLE
fix: Windows shortcut keys are invalid

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
       {
         "command": "vscode-toggle-dynamic-prop.toggleDynamicProp",
         "key": "ctrl+t",
-        "when": "isWin"
+        "when": "isWindows"
       }
     ]
   },


### PR DESCRIPTION
修复 windows下快捷键无效

https://code.visualstudio.com/api/references/when-clause-contexts#available-context-keys

这是我第一次使用GitHub 提交PR，如果有问题的地方，希望提醒我😁